### PR TITLE
Fix bug where it expects subfields to always be set

### DIFF
--- a/src/app/Library/CrudPanel/Traits/Update.php
+++ b/src/app/Library/CrudPanel/Traits/Update.php
@@ -165,7 +165,7 @@ trait Update
                 }
 
                 // when subfields exists developer used the repeatable interface to manage this relation
-                if ($field['subfields']) {
+                if (isset($field['subfields'])) {
                     return [$this->getSubfieldsValues($field['subfields'], $model)];
                 }
 


### PR DESCRIPTION
## WHY
Because I can not edit a thing when having a hasOne relationship.

### BEFORE - What was wrong? What was happening before this PR?
It was coming with the error "Undefined array key "subfields""

### AFTER - What is happening after this PR?

The page works as intended.


## HOW

By checking whether the $field['subfields'] is set.

### How did you achieve that, in technical terms?

if(isset($field['subfields']) {



### Is it a breaking change?

No.


### How can we test the before & after?

By creating a hasOne relationship and not setting subfields
